### PR TITLE
apply same fix for numpy 2.x broadcasting as in previous commit

### DIFF
--- a/hpl2netCDF_client/wind_proc.py
+++ b/hpl2netCDF_client/wind_proc.py
@@ -191,9 +191,16 @@ def lvl2vad_standard(ds_tmp, date_chosen, confDict):
             UVW[kk, ...] = np.squeeze(V_k)
             # plausible winds can only be calculated, when the at least three LOS measurements are present
             UVW[kk, np.sum(~np.isnan(VR_CNSmax.T), axis=1) < 4, :] = np.squeeze(np.full((3, 1), np.nan))
-
-            UVWunc[kk, ...] = abs(np.einsum('...ii->...i', np.sqrt(
-                (A_r_MP @ np.apply_along_axis(np.diag, 1, SIGMA_r ** 2) @ A_r_MP_T).astype(complex)).real))
+            
+            UVWunc[kk, ...] = abs(
+                np.einsum(
+                    '...ii->...i',
+                    np.sqrt(
+                        np.einsum('nik,nk,nkl->nil', A_r_MP, SIGMA_r ** 2, A_r_MP_T).astype(complex)
+                    ).real
+                )
+            )
+            
             # plausible winds can only be calculated, when the at least three LOS measurements are present
             UVWunc[kk, np.sum(~np.isnan(VR_CNSmax.T), axis=1) < 4, :] = np.squeeze(np.full((3, 1), np.nan))
 


### PR DESCRIPTION
Hi,

processing level 1 to level 2, I encountered the error below. I saw that a previous commit (9be99b5) fixed broadcasting issues and found that lines 195-196 of wind_proc.py were identical to the lines changed in the previous commit. So I applied the same fix and the error didn't come back. Note that I honestly don't really understand what that line and the fix does!

Best,
Achim

This is the error I had:

```
processing lvl1 to lvl2...
processing 'Streamline-VAD' setting!
processed 0.0 %
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\admin\AppData\Local\Programs\Python\Python314\Scripts\hpl2netCDF-client.exe\__main__.py", line 6, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\Users\admin\AppData\Local\Programs\Python\Python314\Lib\site-packages\hpl2netCDF_client\command_line.py", line 82, in main
    proc_dl.dailylvl2()
    ~~~~~~~~~~~~~~~~~^^
  File "C:\Users\admin\AppData\Local\Programs\Python\Python314\Lib\site-packages\hpl2netCDF_client\hpl2netCDF_client.py", line 189, in dailylvl2
    ds_lvl2 = process_dataset(ds_tmp, date_chosen, confDict)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python314\Lib\site-packages\hpl2netCDF_client\main_proc.py", line 38, in process_dataset
    ds_lvl2 = lvl2vad_standard(ds_tmp, date_chosen, confDict)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python314\Lib\site-packages\hpl2netCDF_client\wind_proc.py", line 196, in lvl2vad_standard
    (A_r_MP @ np.apply_along_axis(np.diag, 1, SIGMA_r ** 2) @ A_r_MP_T).astype(complex)).real))
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  File "C:\Users\admin\AppData\Local\Programs\Python\Python314\Lib\site-packages\numpy\ma\core.py", line 3151, in __array_wrap__
    m = functools.reduce(mask_or, [getmaskarray(arg) for arg in input_args])
  File "C:\Users\admin\AppData\Local\Programs\Python\Python314\Lib\site-packages\numpy\ma\core.py", line 1802, in mask_or
    return make_mask(umath.logical_or(m1, m2), copy=copy, shrink=shrink)
                     ~~~~~~~~~~~~~~~~^^^^^^^^
ValueError: operands could not be broadcast together with shapes (200,3,12) (200,12,12)
```